### PR TITLE
Vlan manual create

### DIFF
--- a/Create_Secure_Perimeter/secure_perimeter/main.tf
+++ b/Create_Secure_Perimeter/secure_perimeter/main.tf
@@ -55,8 +55,6 @@ module "network" {
     slusername = "${module.sl_credentials.username}"
     slapikey = "${module.sl_credentials.apikey}"
     sps_subnet_size = "${var.sps_subnet_size}"
-    f_router_hostname = "${var.f_router_hostname}"
-    b_router_hostname = "${var.b_router_hostname}"
     sps_public_vlan_name = "${var.public_vlan_name}"
     sps_private_vlan_name = "${var.private_vlan_name}"
     region = "${var.region}"

--- a/Create_Secure_Perimeter/secure_perimeter/main.tf
+++ b/Create_Secure_Perimeter/secure_perimeter/main.tf
@@ -57,6 +57,8 @@ module "network" {
     sps_subnet_size = "${var.sps_subnet_size}"
     f_router_hostname = "${var.f_router_hostname}"
     b_router_hostname = "${var.b_router_hostname}"
+    sps_public_vlan_name = "${var.public_vlan_name}"
+    sps_private_vlan_name = "${var.private_vlan_name}"
     region = "${var.region}"
 }
 

--- a/Create_Secure_Perimeter/secure_perimeter/modules/network/variables.tf
+++ b/Create_Secure_Perimeter/secure_perimeter/modules/network/variables.tf
@@ -21,15 +21,6 @@ variable "random_id" {
    description = "Random ID for naming resources"
 }
 
-variable "f_router_hostname" {
-   type = "string"
-   description = "Name of front router hostname to deploy secure perimeter"
-}
-
-variable "b_router_hostname" {
-    type = "string"
-    description = "Name of back router hostname to deploy secure perimeter"
-}
 
 variable "region" {
     description = "Region name - for example us-south, us-east etc"

--- a/Create_Secure_Perimeter/secure_perimeter/modules/network/variables.tf
+++ b/Create_Secure_Perimeter/secure_perimeter/modules/network/variables.tf
@@ -35,4 +35,10 @@ variable "region" {
     description = "Region name - for example us-south, us-east etc"
 }
    
+variable "sps_public_vlan_name" {
+    description = "Public vlan name"
+}
 
+variable "sps_private_vlan_name" {
+    description = "Private vlan name"
+}

--- a/Create_Secure_Perimeter/secure_perimeter/variables.tf
+++ b/Create_Secure_Perimeter/secure_perimeter/variables.tf
@@ -41,6 +41,14 @@ variable "datacenter" {
   description = "The data center for the cluster, You can get the list with by running bluemix cs locations for example dal13."
   default = ""
 }
+variable "public_vlan_name" {
+    description = "Public vlan name"
+    default = ""
+}
+variable "private_vlan_name" {
+    description = "Private vlan name"
+    default = ""
+}
 
 
 variable "cluster_name" {

--- a/Create_Secure_Perimeter/secure_perimeter/variables.tf
+++ b/Create_Secure_Perimeter/secure_perimeter/variables.tf
@@ -25,14 +25,6 @@ variable "sps_subnet_size" {
   description = "VPCS Subnet Size 8|16|32|64"
   default = 8
 }
-variable "f_router_hostname" {
-  description = "Name of front router hostname to deploy secure perimeter for example fcr02a.dal13"
-  default = ""
-}
-variable "b_router_hostname" {
-  description = "Name of back router hostname to deploy secure perimeter for example bcr02a.dal13"
-  default = ""
-}
 variable "region" {
   description = "The IBM Cloud region where you want to deploy your cluster for example us-south."
   default = ""

--- a/Create_Secure_Perimeter_Segment/variables.tf
+++ b/Create_Secure_Perimeter_Segment/variables.tf
@@ -1,11 +1,16 @@
 variable "bluemix_api_key" {
   description = "Your IBM Cloud API key. You can get the value by running bx iam api-key-create <key name>."
-  default = ""
 }
 
 variable "gateway_name_id" {
   description = "The name or ID of the gateway to deploy segment into"
-  default = ""
+}
+
+variable "public_vlan_name" {
+    description = "Public vlan name"
+}
+variable "private_vlan_name" {
+    description = "Private vlan name"
 }
 
 variable "vlan_subnet_size" {
@@ -15,15 +20,12 @@ variable "vlan_subnet_size" {
 
 variable "org" {
   description = "Your IBM Cloud org name."
-  default = ""
 }
 
 variable "space" {
   description = "Your IBM Cloud space name."
-  default = ""
 }
 
 variable "region" {
   description = "The IBM Cloud region where you want to deploy your cluster for example us-south."
-  default = ""
 }


### PR DESCRIPTION
Non ibm customers do not have the ability to automatically create VLANS and instead need to open a ticket to get VLAN created - so modifying code so that the user must now input the names of the previously created VLANs to the automation. The automation will pick up the new vlans and automatically assoicate them with the vyatta it creates.